### PR TITLE
Experimental branch

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -38,9 +38,11 @@ Or maybe I should ask for MenhirSdk interface to be a bit more flexible.
 
 ## Correction
 
-- The current implementation of **captures** is incorrect. In presence of non-determinism, if there are multiple occurrences of the capture, it will always keep the most recent one, though the matching branch might refer to a previous occurrence.
-
 - The interpreter does not keep track of lookahead, this can cause incorrect reductions to appear in hinted reductions (also, those hints should include the lookahead tokens)
+- Coverage check stops after the first error for a given branch - but a subset of the lookahead might permit reaching other errors
+
+Fixed in PR#2:
+- The current implementation of **captures** is incorrect. In presence of non-determinism, if there are multiple occurrences of the capture, it will always keep the most recent one, though the matching branch might refer to a previous occurrence.
 
 ## Performance
 
@@ -48,7 +50,7 @@ Or maybe I should ask for MenhirSdk interface to be a bit more flexible.
   - Keeping an NFA longer won't increase the performance of the generator itself, but will help with coverage analysis.
   - For reduction simulation, one of the main trick to increase performance.
   - Maybe we don't need DFA at all, runtime matching performance might be sufficient with an NFA? We can experiment if DFA size becomes problematic.
-  - Keeping an NFA will help implementing the **correct capture semantics**.
+  - Keeping an NFA will help implementing the **correct capture semantics**. (Fixed in PR#2, however I maintain that NFA will be more helpful!)
 - The automaton we produce is not optimized at the moment. Some dead branches could be cleaned up, and a minimization algorithm will help (an extension of Valmari to "partial transition functions", or some heuristics applied either on the NFA or the DFA)
 
 ### Datastructures
@@ -70,3 +72,5 @@ I think that an LR parser for Elm syntax with comparable error messages quality 
 
 - [Elm's parser](https://github.com/elm/compiler/tree/master/compiler/src/Parse)
 - [Elm's syntax errors](https://github.com/elm/compiler/blob/master/compiler/src/Reporting/Error/Syntax.hs)
+
+Also for "brace-based" languages, it might be possible to have a finer-grained characterization of errors than existing tools permit (with possibly the exception of heavily instrumented manually written parsers). For instance, it should be possible to switch between expression/statement/block-level analysis for each pattern.

--- a/lib/utils/indexMap.ml
+++ b/lib/utils/indexMap.ml
@@ -46,12 +46,11 @@ module type S = sig
   val of_seq : ('n index * 'a) Seq.t -> ('n, 'a) t
 end
 
-module RawIntMap = Map.Make(Int)
 module IntMap = struct
   type 'n index = int
-  type (+'n, !'a) t = 'a RawIntMap.t
+  type (+'n, !'a) t = 'a IntMap.t
 
-  include (RawIntMap : Map.S with type key := int and type 'a t := 'a RawIntMap.t)
+  include (IntMap : Map.S with type key := int and type 'a t := 'a IntMap.t)
 end
 
 module F(X : Index.Unsafe.T) = struct

--- a/lib/utils/intMap.ml
+++ b/lib/utils/intMap.ml
@@ -1,0 +1,1 @@
+include Map.Make(Int)

--- a/lib/utils/intMap.mli
+++ b/lib/utils/intMap.mli
@@ -1,0 +1,1 @@
+include Map.S with type key = int

--- a/lib/utils/intSet.ml
+++ b/lib/utils/intSet.ml
@@ -1,3 +1,5 @@
+module type S = SetSig.S0
+
 (* A compressed (or should we say sparse?) bit set is a list of pairs
      of integers. The first component of every pair is an index, while
      the second component is a bit field. The list is sorted by order

--- a/lib/utils/intSet.mli
+++ b/lib/utils/intSet.mli
@@ -1,1 +1,2 @@
-include SetSig.S0 with type element = int
+module type S = SetSig.S0
+include S with type element = int

--- a/lib/utils/misc.ml
+++ b/lib/utils/misc.ml
@@ -1,5 +1,16 @@
 open Fix.Indexing
 
+let compare_ignore _ _ = 0
+
+let compare_pair fst snd (x1, y1) (x2, y2) =
+  match fst x1 x2 with
+  | 0 -> snd y1 y2
+  | n -> n
+
+let compare_fst f = compare_pair f compare_ignore
+
+let compare_snd f = compare_pair compare_ignore f
+
 (** [array_last arr] returns the [Some x] where [x] is the last element
     of the array, or [None] if the array is empty *)
 let array_last arr = match Array.length arr with
@@ -15,6 +26,21 @@ let rec array_findi f i arr =
     i
   else
     array_findi f (i + 1) arr
+
+let array_split a =
+  (Array.map fst a, Array.map snd a)
+
+let array_compare cmp a1 a2 =
+  let len = Array.length a1 in
+  let c = Int.compare len (Array.length a2) in
+  if c <> 0 then c else
+    let rec loop i len =
+      if i = len then 0 else
+        let c = cmp a1.(i) a2.(i) in
+        if c <> 0 then c else
+          loop (i + 1) len
+    in
+    loop 0 len
 
 (** [group ~compare ~group list]
     Group togethers the elements of [list] that are equivalent according to
@@ -190,19 +216,6 @@ let sort_and_merge compare merge l =
 let sort_and_merge_indexed compare l =
   let union_ix ix (_, ix') = IndexSet.union ix ix' in
   sort_and_merge
-    (fun (x, _) (y, _) -> compare x y)
+    (compare_fst compare)
     (fun (x, ix) rest -> (x, List.fold_left union_ix ix rest))
     l
-
-let array_compare cmp a1 a2 =
-  let len = Array.length a1 in
-  let c = Int.compare len (Array.length a2) in
-  if c <> 0 then c else
-    let rec loop i len =
-      if i = len then 0 else
-        let c = cmp a1.(i) a2.(i) in
-        if c <> 0 then c else
-          loop (i + 1) len
-    in
-    loop 0 len
-

--- a/ocaml/parse_errors.mlyl
+++ b/ocaml/parse_errors.mlyl
@@ -8,21 +8,15 @@ rule error_message token = parse error
   partial {
     match token with
     | Parser_raw.ELSE -> (
-      match e with
-      | None -> assert false
-      | Some (Parser_raw.MenhirInterpreter.Element (state, expr, startp, _endp)) ->
-        match Parser_raw.MenhirInterpreter.incoming_symbol state with
-        | N N_expr -> (
-        match expr.pexp_desc with
-        | Pexp_ifthenelse(_, _, None) ->
-          Some ("The semicolon line "
-                ^ string_of_int startp.pos_lnum
-                ^ ", character "
-                ^ string_of_int (startp.pos_cnum - startp.pos_bol)
-                ^ " terminates the `if ... then ...` expression. \
-                   Remove it to add an else branch."
-                   )
-        | _ -> None
+      let Parser_raw.MenhirInterpreter.Element (state, expr, startp, _endp) = e in
+      match Parser_raw.MenhirInterpreter.incoming_symbol state, expr with
+      | N N_expr, {pexp_desc = Pexp_ifthenelse(_, _, None); _} -> (
+        Some ("The semicolon line "
+              ^ string_of_int startp.pos_lnum
+              ^ ", character "
+              ^ string_of_int (startp.pos_cnum - startp.pos_bol)
+              ^ " terminates the `if ... then ...` expression. \
+              Remove it to add an else branch.")
         )
       | _ -> None
       )
@@ -40,18 +34,21 @@ rule error_message token = parse error
 | structure_item; !; SEMI as semi;
   LET; ext; list(attribute); rec_flag; let_binding_body; !
 
-  { match semi with
-    | None -> assert false
-    | Some (Parser_raw.MenhirInterpreter.Element (_, _, startp, _endp)) ->
-      "Might be due to the semicolon line "
-      ^ string_of_int startp.pos_lnum
-      ^ ", character "
-      ^ string_of_int (startp.pos_cnum - startp.pos_bol)
+  { let Parser_raw.MenhirInterpreter.Element (_, _, startp, _endp) = semi in
+    "Might be due to the semicolon line "
+    ^ string_of_int startp.pos_lnum
+    ^ ", character "
+    ^ string_of_int (startp.pos_cnum - startp.pos_bol)
   }
 
 (* Replace builtin grammatical rule reporting unclosed parenthesis *)
-| LPAREN; [. RPAREN]; !
-  { "Unclosed parenthesis" }
+| LPAREN as lp; [. RPAREN]; !
+  { let Parser_raw.MenhirInterpreter.Element (_, _, startp, _endp) = lp in
+    "Unclosed parenthesis at line " 
+    ^ string_of_int startp.pos_lnum
+    ^ ", character "
+    ^ string_of_int (startp.pos_cnum - startp.pos_bol)
+  }
 
 (* https://github.com/ocaml/ocaml/issues/11108
    Report when a keyword has been typed in a context where a lowercase

--- a/ocaml/parse_errors.mlyl
+++ b/ocaml/parse_errors.mlyl
@@ -8,9 +8,8 @@ rule error_message token = parse error
   partial {
     match token with
     | Parser_raw.ELSE -> (
-      let Parser_raw.MenhirInterpreter.Element (state, expr, startp, _endp) = e in
-      match Parser_raw.MenhirInterpreter.incoming_symbol state, expr with
-      | N N_expr, {pexp_desc = Pexp_ifthenelse(_, _, None); _} -> (
+      match e with 
+      | {pexp_desc = Pexp_ifthenelse(_, _, None); _}, startp, _endp -> (
         Some ("The semicolon line "
               ^ string_of_int startp.pos_lnum
               ^ ", character "
@@ -33,8 +32,7 @@ rule error_message token = parse error
 
 | structure_item; !; SEMI as semi;
   LET; ext; list(attribute); rec_flag; let_binding_body; !
-
-  { let Parser_raw.MenhirInterpreter.Element (_, _, startp, _endp) = semi in
+  { let (), startp, _endp = semi in
     "Might be due to the semicolon line "
     ^ string_of_int startp.pos_lnum
     ^ ", character "
@@ -43,7 +41,7 @@ rule error_message token = parse error
 
 (* Replace builtin grammatical rule reporting unclosed parenthesis *)
 | LPAREN as lp; [. RPAREN]; !
-  { let Parser_raw.MenhirInterpreter.Element (_, _, startp, _endp) = lp in
+  { let (), startp, _endp = lp in
     "Unclosed parenthesis at line " 
     ^ string_of_int startp.pos_lnum
     ^ ", character "

--- a/src/back/dfa.ml
+++ b/src/back/dfa.ml
@@ -82,12 +82,16 @@ struct
       let reduce = ref [] in
       let loop k = KRESet.derive_kre ~visited ~accept ~reduce ~direct k in
       KRESet.iter loop t.direct;
-      let tr =
-        let reduce = CachedKRESet.lift (KRESet.of_list !reduce) in
-        let compiled = Red.compile reduction_cache reduce in
+      let reduce_one kre =
+        let compiled =
+          Red.compile reduction_cache (CachedKRESet.lift (KRESet.singleton kre))
+        in
         (*Printf.eprintf "compiled reductions:\n%a\n"
           print_cmon (Red.cmon compiled);*)
         lift_red (Red.initial compiled)
+      in
+      let tr =
+        List.concat_map reduce_one (List.sort_uniq KRE.compare !reduce)
       in
       let tr = RedSet.fold add_redset t.reduce tr in
       let tr =

--- a/src/back/dfa.ml
+++ b/src/back/dfa.ml
@@ -279,6 +279,9 @@ struct
   let label  tr = tr.label
   let source tr = tr.source
   let target tr = tr.target
+  let all_vars tr =
+    Array.fold_left (fun acc map -> IndexMap.fold (fun _ -> IndexSet.union) map acc)
+      IndexSet.empty tr.direct_map
 
   let index    st = st.index
   let forward  st = st.forward

--- a/src/back/regalloc.ml
+++ b/src/back/regalloc.ml
@@ -1,0 +1,125 @@
+open Fix.Indexing
+open Utils
+open Misc
+
+module Make (Dfa: Sigs.DFA) = struct
+  (*module RegMap = Map.Make(struct
+      type t = Dfa.thread index * RE.var index
+      let compare (t1, v1) (t2, v2) =
+        let c = compare_index t1 t2 in
+        if c <> 0 then c else
+          compare_index v1 v2
+    end)*)
+
+  (*type regset = (Dfa.thread, IntSet.t) indexmap*)
+
+  (*type register_bank = {
+    mapping: int RegMap.t;
+    count: int;
+  }
+
+  let empty = {
+    mapping = RegMap.empty;
+    count = 0;
+  }
+
+  let alloc bank key =
+    match RegMap.find_opt key bank.mapping with
+    | Some _ -> bank
+    | None ->
+      let mapping = RegMap.add key bank.count bank.mapping in
+      {mapping; count = bank.count + 1}*)
+
+  (*let alloc bank key =
+    match RegMap.find_opt key bank.mapping with
+    | Some var -> bank, var
+    | None ->
+      let mapping = RegMap.add key bank.count bank.mapping in
+      {mapping; count = bank.count + 1}, bank.count*)
+
+  let liveness vars dfa =
+    let count = Array.length dfa in
+    let registers = Array.make count IndexMap.empty in
+    let pending = Array.make count IndexMap.empty in
+    let todo = ref [] in
+    Array.iter (fun st ->
+        match Dfa.accepted st with
+        | [] -> ()
+        | accepted ->
+          push todo (Dfa.index st);
+          let set = ref IndexMap.empty in
+          List.iter (fun (clause, thread) ->
+              let vars = vars.(Index.to_int clause) in
+              set := IndexMap.add thread vars !set;
+            ) accepted;
+          pending.(Dfa.index st) <- !set;
+      ) dfa;
+    let schedule st vars =
+      if not (IndexMap.is_empty vars) then (
+        let vars' = pending.(st) in
+        if IndexMap.is_empty vars' then (
+          push todo st;
+          pending.(st) <- vars
+        ) else
+          pending.(st) <- IndexMap.union
+              (fun _ s1 s2 -> Some (IndexSet.union s1 s2)) vars vars';
+      )
+    in
+    let process_pending st =
+      let p = pending.(st) in
+      let r = registers.(st) in
+      let p = IndexMap.filter_map (fun tr vars ->
+          match IndexMap.find_opt tr r with
+          | None -> Some vars
+          | Some vars' ->
+            let vars = IndexSet.diff vars vars' in
+            if IndexSet.is_empty vars then
+              None
+            else
+              Some vars
+        ) p
+      in
+      registers.(st) <- IndexMap.union (fun _ s1 s2 ->
+          Some (IndexSet.union s1 s2)
+        ) p r;
+      pending.(st) <- IndexMap.empty;
+      IndexMap.iter (fun target_thread vars ->
+          List.iter (fun tr ->
+              let mapping = Dfa.reverse_mapping tr ~target_thread in
+              let vars =
+                IndexMap.filter_map (fun _ vars' ->
+                    let vars = IndexSet.diff vars vars' in
+                    if IndexSet.is_empty vars then
+                      None
+                    else
+                      Some vars
+                  ) mapping
+              in
+              schedule (Dfa.source tr) vars
+            ) (Dfa.backward dfa.(st))
+        ) p
+    in
+    let rec loop () =
+      match !todo with
+      | [] -> ()
+      | todo' ->
+        todo := [];
+        List.iter process_pending todo';
+        loop ()
+    in
+    loop ();
+    let optional_var =
+      IndexMap.fold
+        (fun _ vars acc -> acc + IndexSet.cardinal vars)
+        registers.(0) 0
+    in
+    let max_count =
+      Array.fold_left
+        (fun acc bank -> max acc (IndexMap.fold (fun _ set acc -> acc + IndexSet.cardinal set) bank 0))
+        0 registers
+    in
+    Printf.eprintf "optional variables: %d\n" optional_var;
+    Printf.eprintf "max register count: %d\n" max_count;
+    max_count, registers
+
+end

--- a/src/back/sigs.ml
+++ b/src/back/sigs.ml
@@ -19,6 +19,7 @@ module type DFA = sig
   val source : transition -> state_index
   val target : transition -> state_index
   val reverse_mapping : transition -> target_thread:thread index -> (thread, RE.var indexset) indexmap
+  val all_vars : transition -> RE.var indexset
 
   val index : state -> state_index
   val forward : state -> transition list

--- a/src/back/sigs.ml
+++ b/src/back/sigs.ml
@@ -18,11 +18,12 @@ module type DFA = sig
   val label : transition -> Lr1.set
   val source : transition -> state_index
   val target : transition -> state_index
+  val reverse_mapping : transition -> target_thread:thread index -> (thread, RE.var indexset) indexmap
 
   val index : state -> state_index
   val forward : state -> transition list
   val backward : state -> transition list
-  val accepted : state -> (KRE.clause index * thread indexset) list
+  val accepted : state -> (KRE.clause index * thread index) list
 
   type dfa = state array
 
@@ -30,9 +31,11 @@ module type DFA = sig
       The initial state is the first element of the array. *)
   val derive_dfa : KRESet.t -> dfa
 
+  type liveness = (thread, RE.var indexset) indexmap array
+
   (** Compile a DFA to a compact table, suitable for use with Lrgrep_support
       and runtime libraries. *)
-  val gen_table : dfa -> Lrgrep_support.compact_dfa
+  val gen_table : dfa -> liveness -> Lrgrep_support.compact_dfa
 
   (** FIXME: Cleanup *)
   val eval : dfa -> state_index -> stack:Lr1.t list -> unit

--- a/src/back/sigs.ml
+++ b/src/back/sigs.ml
@@ -1,63 +1,39 @@
-open Utils
+open Fix.Indexing
+open Utils.Misc
 
 module type DFA = sig
   module Regexp : Mid.Sigs.REGEXP
   open Regexp
   open Info
 
-  (** Our final notion of expression.
-      Internally its a tuple of:
-      - a set of regular expressions (implemented by [KRE])
-      - a set of ongoing reductions (implemented by [Reduction]).
-  *)
-  module Expr : sig
-    type t
-    val make : KRESet.t -> t
-    val cmon : t -> Cmon.t
-    val compare : t -> t -> int
-    val empty : t
-    val union : t -> t -> t
+  type state_index = int
+  type state
 
-    (** FIXME: Cleanup *)
-    val interpret : t -> stack:Lr1.t list -> unit
-  end
+  type thread
+  val thread : int -> thread index
 
-  (** States of the DFA are keyed by expression, therefore they are represented
-      by an [ExprMap.t] *)
-  module ExprMap : Map.S with type key = Expr.t
+  val threads : state -> int
 
-  module State : sig
-    type t
-    val id : t -> int
+  type transition
+  val label : transition -> Lr1.set
+  val source : transition -> state_index
+  val target : transition -> state_index
 
-    (** The indices of clauses matching in this state *)
-    val accepted : t -> IntSet.t
+  val index : state -> state_index
+  val forward : state -> transition list
+  val backward : state -> transition list
+  val accepted : state -> (KRE.clause index * thread indexset) list
 
-    (** Iterate through all outgoing transitions of a state.
-        Transitions are given by three arguments:
-        - a set of lr1 states that label the transition (it should be followed
-          only when the state of an LR stack frame belongs to this set)
-        - a list of variables to update, if the transition is taken,
-          with the matching LR stack frame
-        - a target DFA state *)
-    val iter_transitions : t -> (Lr1.set -> RE.var list -> t -> unit) -> unit
-  end
+  type dfa = state array
 
-  (** A DFA is a map from expression to state *)
-  type t = State.t ExprMap.t
-
-  (** Number of states in the DFA / cardinal of the map *)
-  val number_of_states : t -> int
-
-  (** Produce a DFA from an initial expression.
-      Returns a pair [(dfa, state)] of the dfa and the initial state matching
-      expression *)
-  val derive_dfa : Expr.t -> t * State.t
+  (** Produce a DFA from an initial expression, as an array.
+      The initial state is the first element of the array. *)
+  val derive_dfa : KRESet.t -> dfa
 
   (** Compile a DFA to a compact table, suitable for use with Lrgrep_support
       and runtime libraries. *)
-  val gen_table : t -> Lrgrep_support.compact_dfa
+  val gen_table : dfa -> Lrgrep_support.compact_dfa
 
   (** FIXME: Cleanup *)
-  val eval : t -> State.t -> stack:Lr1.t list -> unit
+  val eval : dfa -> state_index -> stack:Lr1.t list -> unit
 end

--- a/src/mid/redgraph.ml
+++ b/src/mid/redgraph.ml
@@ -66,18 +66,17 @@ struct
   let init_root lr1 =
     let rec visit_reductions n states = function
       | [] -> {states; goto_nt = IndexMap.empty; parent = None}
-      | (n', prod, _, ts) :: rest when n = n' ->
+      | (c : Lr1.closed_reduction) :: rest when c.pop = n ->
         let result = visit_reductions n states rest in
-        let nt = Production.lhs prod in
         let goto_nt =
-          IndexMap.update nt (function
-              | None -> Some ts
-              | Some ts' -> Some (IndexSet.union ts ts')
+          IndexMap.update (Production.lhs c.prod) (function
+              | None -> Some c.lookahead
+              | Some ts' -> Some (IndexSet.union c.lookahead ts')
             ) result.goto_nt
         in
         {result with goto_nt}
-      | ((n', _, _, _) :: _) as reds ->
-        assert (n' > n);
+      | (c :: _) as reds ->
+        assert (c.pop > n);
         let frame = visit_reductions (n + 1) (Lr1.set_predecessors states) reds in
         {states; goto_nt = IndexMap.empty; parent = Some (new_intermediate frame)}
     in

--- a/src/mid/sigs.ml
+++ b/src/mid/sigs.ml
@@ -379,7 +379,7 @@ module type REGEXP = sig
           consumed by one of the reduction simulated by the first [!]).
         [derive_in_reduction] implements this simpler notion.
     *)
-    val derive_in_reduction : t -> t partial_derivative list
+    val derive_in_reduction : t -> (t * RE.var indexset) partial_derivative list
 
     (** Print a set of KREs to a cmon document. *)
     val cmon : t -> Cmon.t

--- a/src/mid/sigs.ml
+++ b/src/mid/sigs.ml
@@ -133,7 +133,12 @@ module type INFO = sig
         pop enough states such that the current state is popped.
         Therefore, [pop >= 1].
     *)
-    type closed_reduction = (int * Production.t * Production.t list * Terminal.set)
+    type closed_reduction = {
+      pop: int;
+      prod: Production.t;
+      prods: Production.t list;
+      lookahead: Terminal.set;
+    }
     val closed_reductions : t -> closed_reduction list
 
     (** All the stacks that were visited during ϵ-closure. This is used

--- a/support/lrgrep_runtime.ml
+++ b/support/lrgrep_runtime.ml
@@ -50,8 +50,8 @@ let program_step (t : program) (r : program_counter ref)
     r := !r + 3;
     Move (String.get_uint8 t (pc + 1), String.get_uint8 t (pc + 2))
   | '\x03' ->
-    r := !r + 3;
-    Yield (String.get_uint16_be t (pc + 1))
+    r := !r + 4;
+    Yield (get_int t ~offset:(pc + 1) 3)
   | '\x04' ->
     r := !r + 4;
     Accept (String.get_uint8 t (pc + 1),

--- a/support/lrgrep_runtime.ml
+++ b/support/lrgrep_runtime.ml
@@ -1,8 +1,6 @@
 type lr1 = int
 type clause = int
-type var = int
-type register = clause * var
-type arities = int array
+type register = int
 
 (* Representation of automaton as sparse tables and bytecoded programs *)
 
@@ -14,6 +12,7 @@ type program_counter = int
 
 type program_instruction =
   | Store of register
+  | Move of register * register
   | Yield of program_counter
   | Accept of clause
   | Match of sparse_index
@@ -45,24 +44,27 @@ let program_step (t : program) (r : program_counter ref)
   let pc = !r in
   match t.[pc] with
   | '\x01' ->
-    r := !r + 3;
-    Store (String.get_uint8 t (pc + 1), String.get_uint8 t (pc + 2))
+    r := !r + 2;
+    Store (String.get_uint8 t (pc + 1))
   | '\x02' ->
     r := !r + 3;
-    Yield (String.get_uint16_be t (pc + 1))
+    Move (String.get_uint8 t (pc + 1), String.get_uint8 t (pc + 2))
   | '\x03' ->
+    r := !r + 3;
+    Yield (String.get_uint16_be t (pc + 1))
+  | '\x04' ->
     r := !r + 2;
     Accept (String.get_uint8 t (pc + 1))
-  | '\x04' ->
+  | '\x05' ->
     r := !r + 3;
     Match (String.get_uint16_be t (pc + 1))
-  | '\x05' ->
+  | '\x06' ->
     r := !r + 1;
     Halt
   | _ -> assert false
 
 module type Parse_errors = sig
-  val arities : int array
+  val registers : int
   val initial : program_counter
   val table : sparse_table
   val program : program
@@ -83,16 +85,20 @@ struct
     let pc = ref pc in
     let rec loop () =
       match program_step PE.program pc with
-      | Store (clause, var) ->
+      | Store reg ->
         (*prerr_endline "Store";*)
-        bank.(clause).(var) <- P.top env;
+        bank.(reg) <- P.top env;
+        loop ()
+      | Move (r1, r2) ->
+        (*prerr_endline "Store";*)
+        bank.(r1) <- bank.(r2);
         loop ()
       | Yield pc' ->
         (*prerr_endline "Yield";*)
         Some pc'
       | Accept clause ->
         (*prerr_endline "Accept";*)
-        candidate := clause :: !candidate;
+        candidate := (clause, Array.copy bank) :: !candidate;
         loop ()
       | Match index ->
         (*prerr_endline "Match";*)
@@ -113,7 +119,7 @@ struct
     loop ()
 
   let run env =
-    let bank = Array.map (fun a -> Array.make a None) PE.arities in
+    let bank = Array.make PE.registers None in
     let candidate = ref [] in
     let rec loop env pc =
       match interpret bank env candidate pc with
@@ -127,6 +133,5 @@ struct
     in
     loop env PE.initial;
     !candidate
-    |> List.sort_uniq Int.compare
-    |> List.map (fun clause -> clause, bank.(clause))
+    |> List.sort_uniq (fun (a,_) (b,_) -> Int.compare a b)
 end

--- a/support/lrgrep_runtime.mli
+++ b/support/lrgrep_runtime.mli
@@ -56,7 +56,7 @@ type program_instruction =
     (** Jump and consume input:
         [Yield pc] stops the current interpretation to consume one state of the
         input stack. After consuming, execution should resume at [pc]. *)
-  | Accept of clause
+  | Accept of clause * int * int
     (** When reaching [Accept id], the matcher found that clause number [id] is
         matching. Add it to the set of matching candidates and resume
         execution. *)

--- a/support/lrgrep_runtime.mli
+++ b/support/lrgrep_runtime.mli
@@ -10,19 +10,8 @@ type lr1 = int
     (generated) client program to map it to a semantic action. *)
 type clause = int
 
-(** Variables are also named by small integers, attributed monotonically
-    starting from 0 by traversing the clause pattern from right to left. *)
-type var = int
-
-(** A register is the pair of a clause and a variable.
-    A variable name is unique only within a clause. *)
-type register = clause * var
-
-(** The arities array describe the number of variables of each clause.
-    For instance, an array [|1; 2|] means the matching program has two clauses
-    the first one with a single variable and the second one with two variables.
-    The corresponding registers are therefor (0, 0), (1, 0) and (1, 1). *)
-type arities = int array
+(** Registers are also named by small integers. *)
+type register = int
 
 (* Representation of the automaton as sparse tables and bytecoded programs *)
 
@@ -62,6 +51,7 @@ type program_instruction =
   | Store of register
     (** [Store r] stores the state at the top of the parser stack in
         register [r]. *)
+  | Move of register * register
   | Yield of program_counter
     (** Jump and consume input:
         [Yield pc] stops the current interpretation to consume one state of the
@@ -89,7 +79,7 @@ val program_step : program -> program_counter ref -> program_instruction
 
 (** All the elements composing a parse error matching program. *)
 module type Parse_errors = sig
-  val arities : int array
+  val registers : int
   val initial : program_counter
   val table : sparse_table
   val program : program

--- a/support/lrgrep_support.ml
+++ b/support/lrgrep_support.ml
@@ -224,8 +224,20 @@ let compact (dfa : dfa) =
   let halt_pc = ref (Code_emitter.position code) in
   Code_emitter.emit code Halt;
   let pcs = Array.init (Array.length dfa) (fun _ -> ref (-1)) in
+  let rec emit_moves = function
+    | (i, j) :: rest ->
+      if i < j then (
+        emit_moves rest;
+        Code_emitter.emit code (Move (i, j));
+      ) else if i > j then (
+        Code_emitter.emit code (Move (i, j));
+        emit_moves rest;
+      ) else
+        emit_moves rest
+    | [] -> ()
+  in
   let emit_action act =
-    List.iter (fun (i, j) -> Code_emitter.emit code (Move (i, j))) act.move;
+    emit_moves act.move;
     List.iter (fun i -> Code_emitter.emit code (Store i)) act.store;
     Code_emitter.emit_yield_reloc code pcs.(act.target);
   in

--- a/support/lrgrep_support.mli
+++ b/support/lrgrep_support.mli
@@ -54,7 +54,7 @@ end
 type transition_action = RT.register list * int
 
 type state = {
-  accept: int option;
+  accept: int list;
   (** a clause to accept in this state.
       FIXME: this should be a set, multiple clauses can match at the same
       state. *)

--- a/support/lrgrep_support.mli
+++ b/support/lrgrep_support.mli
@@ -51,13 +51,15 @@ end
 (** The action of a transition is pair of:
     - a possibly empty list of registers to save the current state to
     - a target state (index of the state in the dfa array) *)
-type transition_action = RT.register list * int
+type transition_action = {
+  move: (RT.register * RT.register) list;
+  store: RT.register list;
+  target: int;
+}
 
 type state = {
-  accept: int list;
-  (** a clause to accept in this state.
-      FIXME: this should be a set, multiple clauses can match at the same
-      state. *)
+  accept: IntSet.t;
+  (** a clause to accept in this state. *)
 
   halting: IntSet.t;
   (** The set of labels that should cause matching to halt (this can be seen as

--- a/support/lrgrep_support.mli
+++ b/support/lrgrep_support.mli
@@ -58,7 +58,7 @@ type transition_action = {
 }
 
 type state = {
-  accept: IntSet.t;
+  accept: (RT.clause * RT.register * int) list;
   (** a clause to accept in this state. *)
 
   halting: IntSet.t;


### PR DESCRIPTION
This branch improves over master in many ways:
- proper liveness analysis for variables, recovering optionality and types
- naive but (supposedly) correct register allocation (properly sufficient)
- bug fixes: variables were dropped when leaving reduction

FIXME:
- [ ] non-determinism: when multiple captures are possible for a variable, one is selected arbitrarily (according to lexical ordering over continuations :P; that's an acceptable behavior, but it still needs cleanup, and maybe a better spec)
- [x] naive register renaming: the code for updating registers implements a permutation via a sequence of move -- but the order of the moves is random right now, which can cause register clobber)