### PR TITLE
Allow exact prefix matches on LR items

### DIFF
--- a/src/front/lexer.mll
+++ b/src/front/lexer.mll
@@ -198,6 +198,7 @@ rule main = parse
 | ',' { COMMA }
 | ';' { SEMI }
 | '.' { DOT }
+| '^' { CARET }
 | eof { EOF }
 | _
   { raise_lexical_error lexbuf

--- a/src/front/parser.mly
+++ b/src/front/parser.mly
@@ -43,6 +43,7 @@ let mk_re desc pos = {desc; position = make_position pos}
        COMMA       ","
        SEMI        ";"
        COLON       ":"
+       CARET       "^"
        AS          "as"
        PARTIAL     "partial"
        (*HASH       "#"*)
@@ -93,8 +94,8 @@ wild_symbol:
 atom:
 | "_"    { Wildcard }
 | symbol { Symbol $1 }
-| "[" lhs=item_lhs prefix=wild_symbol* "." suffix=wild_symbol* "]"
-  { Item {lhs; prefix; suffix} }
+| "[" anchored=boption("^") lhs=item_lhs prefix=wild_symbol* "." suffix=wild_symbol* "]"
+  { Item {lhs; anchored; prefix; suffix} }
 ;
 
 %inline item_lhs:

--- a/src/front/syntax.ml
+++ b/src/front/syntax.ml
@@ -40,6 +40,9 @@ type atom_desc =
       {
         lhs: symbol option;
         (** if specified, the item must have this non-terminal as lhs *)
+        anchored : bool;
+          (** Whether the prefix must exactly match the item, rather
+              than allowing longer productions. *)
         prefix: symbol option list;
         (** the list of producers before the dot *)
         suffix: symbol option list;
@@ -175,11 +178,12 @@ let print_atom_desc = function
     Cmon.construct "Symbol" [print_symbol sym]
   | Wildcard ->
     Cmon.constant "Wildcard"
-  | Item {lhs; prefix; suffix} ->
+  | Item {lhs; anchored; prefix; suffix} ->
     Cmon.crecord "Item" [
-      "lhs"    , print_option print_symbol lhs;
-      "prefix" , Cmon.list (List.map (print_option print_symbol) prefix);
-      "suffix" , Cmon.list (List.map (print_option print_symbol) suffix);
+      "lhs"     , print_option print_symbol lhs;
+      "anchored", Cmon.bool anchored;
+      "prefix"  , Cmon.list (List.map (print_option print_symbol) prefix);
+      "suffix"  , Cmon.list (List.map (print_option print_symbol) suffix);
     ]
 
 let rec print_regular_term = function


### PR DESCRIPTION
This allows using `^` to "anchor" a LR item, requiring the prefix to exactly match the production, rather than allowing longer terms.

## Motivation
Like with #4, this motivating example is for Lua, though I suspect similar patterns occur in other languages!

Lua's primary data structure is a "table", which acts as both an array and a hash map. Each item in the table is defined with the following grammar:

```ocaml
let table_entry :=
  | expr ; {()} (* Array item: { 123 } *)
  | IDENT ; "=" ; expr ; {()} (* Map string key to value: { x = y } *)
  | "[" ; expr ;  "]" ; "=" ; expr (* Map arbitrary key to value: { [f()] = y } *)
  ; {()}
```

It'd be useful to write an error for when a user has written `{ f() = y }`, suggesting they might want `{ [f()] = y }`. We could match against error this with the following pattern:

```ocaml
| [table_entry: expr .]; ! partial {
  match token with | EQUALS -> _ | _ -> _
}
```

However, as syntax items match any prefix, this also matches the `IDENT ; " =" ; expr` production, meaning inputs such `x = y = .` would also (incorrectly) match. With this PR, we can use `^` to require the whole prefix to be specified, and thus only match the first production.

```ocaml
| [^table_entry: expr .]; ! partial {
  match token with | EQUALS -> _ | _ -> _
}
```