### PR TITLE
Generate separate pattern arms for each symbol

### DIFF
--- a/src/mid/automata.ml
+++ b/src/mid/automata.ml
@@ -1480,15 +1480,15 @@ struct
       begin match typ with
         | None -> ()
         | Some (symbols, typ) ->
-          let matchers =
-            List.map symbol_matcher (IndexSet.elements symbols)
-          in
           Printer.fmt out
-            "        let x = match %s.MenhirInterpreter.incoming_symbol st with\n\
-            \          | %s -> (x : %s) \n\
-            \          | _ -> assert false\n\
+            "        let x = match %s.MenhirInterpreter.incoming_symbol st with\n" 
+            E.parser_name;
+            List.iter (fun symbol -> 
+              Printer.fmt out "          | %s -> (x : %s)\n" 
+              (symbol_matcher symbol) typ) (IndexSet.elements symbols);
+            Printer.fmt out
+            "          | _ -> assert false\n\
             \        in\n"
-            E.parser_name (String.concat " | " matchers) typ
       end;
       Printer.fmt out "        (%s, %s, %s)\n" (some "x") (some "startp") (some "endp");
       Printer.fmt out "    in\n";


### PR DESCRIPTION
When multiple symbols may match, we generate code like:

    let x = match Parser_raw.MenhirInterpreter.incoming_symbol st with
    | T T_LPAREN | T T_RPAREN -> (x : unit)
    | _ -> assert false

However, or patterns don't introduce a constraint on the GADT's type variable, so this code fails to compile. Instead, we need to generate a separate arm for each case:

    let x = match Parser_raw.MenhirInterpreter.incoming_symbol st with
    | T T_LPAREN -> (x : unit)
    | T T_RPAREN -> (x : unit)
    | _ -> assert false