### PR TITLE
Add a sentence enumeration feature

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,11 +1,5 @@
 (executable
  (name main)
  (public_name lrgrep)
- (modules main)
- (libraries front mid fix cmon utils menhirSdk valmari support))
-
-(executable
- (name enum)
- (public_name lrgrep-enum)
- (modules enum)
+ (modules main enum)
  (libraries front mid fix cmon utils menhirSdk valmari support))

--- a/src/dune
+++ b/src/dune
@@ -3,3 +3,9 @@
  (public_name lrgrep)
  (modules main)
  (libraries front mid fix cmon utils menhirSdk valmari support))
+
+(executable
+ (name enum)
+ (public_name lrgrep-enum)
+ (modules enum)
+ (libraries front mid fix cmon utils menhirSdk valmari support))

--- a/src/enum.ml
+++ b/src/enum.ml
@@ -266,29 +266,25 @@ struct
       output_string oc (Symbol.name t);
       output_char oc '"'
 
-    let output_item oc (prod, dot) =
-      output_string oc "{\"lhs\":";
-      output_symbol oc (Symbol.inj_r (Production.lhs prod));
-      output_string oc ",\"rhs\":[";
-      let rhs = Production.rhs prod in
-      for i = 0 to dot - 1 do
-        if i <> 0 then output_char oc ';';
-        output_symbol oc rhs.(i);
-      done;
-      output_string oc "],\"dot\":";
-      output_string oc (string_of_int dot);
-      output_char oc '}'
-
-    let output_terminal oc t =
-      output_symbol oc (Symbol.inj_l t)
-
     let output_list f oc xs =
       output_char oc '[';
       List.iteri (fun i x ->
-          if i <> 0 then output_char oc ';';
+          if i <> 0 then output_char oc ',';
           f oc x
         ) xs;
       output_char oc ']'
+
+    let output_item oc (prod, dot) =
+      Printf.fprintf oc
+        "{\"lhs\":%a,\"rhs\":%a,\"dot\":%d}"
+        output_symbol
+          (Symbol.inj_r (Production.lhs prod))
+        (output_list output_symbol)
+          (Array.to_list (Production.rhs prod))
+        dot
+
+    let output_terminal oc t =
+      output_symbol oc (Symbol.inj_l t)
 
     let output_sentence oc (entrypoint, terminals, lookaheads, items) =
       Printf.fprintf oc

--- a/src/enum.ml
+++ b/src/enum.ml
@@ -1,0 +1,383 @@
+open Utils
+
+(* Command-line parsing. *)
+
+let opt_grammar_file = ref None
+let opt_verbose = ref false
+
+let usage =
+  Printf.sprintf
+    "lrgrep, a menhir lexer\n\
+     usage: %s [options] <source>"
+    Sys.argv.(0)
+
+let print_version_num () =
+  print_endline "0.1";
+  exit 0
+
+let print_version_string () =
+  print_string "The Menhir parser lexer generator :-], version ";
+  print_version_num ()
+
+let error {Front.Syntax. line; col} fmt =
+  Printf.eprintf "Error line %d, column %d: " line col;
+  Printf.kfprintf (fun oc -> output_char oc '\n'; flush oc; exit 1) stderr fmt
+
+let warn {Front.Syntax. line; col} fmt =
+  Printf.eprintf "Warning line %d, column %d: " line col;
+  Printf.kfprintf (fun oc -> output_char oc '\n'; flush oc) stderr fmt
+
+let eprintf = Printf.eprintf
+
+let specs = [
+  "-g", Arg.String (fun x -> opt_grammar_file := Some x),
+  " <file.cmly>  Path of the Menhir compiled grammar to analyse (*.cmly)";
+  "-v", Arg.Set opt_verbose,
+  " Increase output verbosity";
+  "-version", Arg.Unit print_version_string,
+  " Print version and exit";
+  "-vnum", Arg.Unit print_version_num,
+  " Print version number and exit";
+]
+
+let () = Arg.parse specs (fun arg -> failwith ("Unexpected argument: " ^ arg)) usage
+
+let grammar_file = match !opt_grammar_file with
+  | Some filename -> filename
+  | None ->
+    Format.eprintf "No grammar provided (-g), stopping now.\n";
+    Arg.usage specs usage;
+    exit 1
+
+let () = Stopwatch.step Stopwatch.main "Beginning"
+
+module Grammar = MenhirSdk.Cmly_read.Read(struct let filename = grammar_file end)
+
+let () = Stopwatch.step Stopwatch.main "Loaded grammar"
+
+module Info = Mid.Info.Make(Grammar)
+module Viable = Mid.Viable_reductions.Make(Info)()
+module Reachability = Mid.Reachability.Make(Info)()
+
+module RawLrc = Mid.Lrc.Make(Info)(Reachability)
+module Lrc = Mid.Lrc.Close(Info)(RawLrc)(struct let initials =
+  Misc.indexset_bind
+    (IndexSet.init_from_set Info.Lr1.n
+      (fun lr1 -> Option.is_none (Info.Lr1.incoming lr1)))
+    RawLrc.lrcs_of_lr1
+end)
+module Reach = Mid.Reachable_reductions.Make(Info)(Viable)(Lrc)()
+
+(*module Failure =  struct
+  (*module Lrc = Mid.Lrc.Minimize(Info)(Lrc)
+  module Reach = Mid.Reachable_reductions.Make(Info)(Viable)(Lrc)()*)
+  module Failure = Mid.Reachable_reductions.FailureNFA(Info)(Viable)(Lrc)(Reach)()
+end*)
+
+open Fix.Indexing
+
+let lrc_prefix =
+  let table = Vector.make Lrc.n [] in
+  let todo = ref [] in
+  let expand prefix state =
+    match Vector.get table state with
+    | [] ->
+      Vector.set table state prefix;
+      let prefix = state :: prefix in
+      let successors = Lrc.successors state in
+      if not (IndexSet.is_empty successors) then
+        Misc.push todo (successors, prefix)
+    | _ -> ()
+  in
+  let visit (successors, prefix) =
+    IndexSet.iter (expand prefix) successors
+  in
+  let rec loop = function
+    | [] -> ()
+    | other ->
+      todo := [];
+      List.iter visit other;
+      loop !todo
+  in
+  Index.iter Info.Lr1.n (fun lr1 ->
+      if Option.is_none (Info.Lr1.incoming lr1) then
+        expand [] (Lrc.first_lrc_of_lr1 lr1)
+    );
+  loop !todo;
+  Vector.get table
+
+module Sentence_gen =
+struct
+  open Info
+
+  let rec cells_of_lrc_list = function
+    | [] -> assert false
+    | [_] ->  []
+    | (x :: (y :: _ as tail)) ->
+      let xl = Lrc.lr1_of_lrc x in
+      let yl = Lrc.lr1_of_lrc y in
+      let yi = Lrc.class_index y in
+      let tr =
+        List.find
+          (fun tr -> Transition.source tr = xl)
+          (Transition.predecessors yl)
+      in
+      let open Reachability in
+      let xi =
+        match Classes.pre_transition tr with
+        | [|c_pre|] when IndexSet.is_singleton c_pre ->
+          if not (IndexSet.subset c_pre (Lrc.lookahead x)) then (
+            Printf.eprintf "pre:%s expected:%s\nfrom:%s to:%s after:%s\n%!"
+              (Misc.string_of_indexset ~index:Terminal.to_string c_pre)
+              (Misc.string_of_indexset ~index:Terminal.to_string (Lrc.lookahead x))
+              (Lr1.to_string xl)
+              (Lr1.to_string yl)
+              (if IndexSet.equal (Lrc.lookahead y) Terminal.all
+                then "all"
+                else Misc.string_of_indexset ~index:Terminal.to_string (Lrc.lookahead y))
+            ;
+            assert false
+          );
+          0
+        | _ -> Lrc.class_index x
+      in
+      let yi = (Coercion.infix (Classes.post_transition tr) (Classes.for_lr1 yl)).backward.(yi)
+      in
+      Cells.encode (Tree.leaf tr) xi yi :: cells_of_lrc_list tail
+
+  exception Break of Terminal.t list
+
+  let rec prepend_word cell acc =
+    let open Reachability in
+    let node, i_pre, i_post = Cells.decode cell in
+    match Tree.split node with
+    | L tr ->
+      (* The node corresponds to a transition *)
+      begin match Transition.split tr with
+        | R shift ->
+          (* It is a shift transition, just shift the symbol *)
+          Transition.shift_symbol shift :: acc
+        | L goto ->
+          (* It is a goto transition *)
+          let nullable, non_nullable = Tree.goto_equations goto in
+          let c_pre = (Tree.pre_classes node).(i_pre) in
+          let c_post = (Tree.post_classes node).(i_post) in
+          if not (IndexSet.is_empty nullable) &&
+            IndexSet.quick_subset c_post nullable &&
+            not (IndexSet.disjoint c_pre c_post) then
+            (* If a nullable reduction is possible, don't do anything *)
+            acc
+          else
+            (* Otherwise look at all equations that define the cost of the
+               goto transition and recursively visit one of minimal cost *)
+            let current_cost = Cells.cost cell in
+            match
+            List.find_map (fun (node', lookahead) ->
+              if IndexSet.disjoint c_post lookahead then
+                (* The post lookahead class does not permit reducing this
+                       production *)
+                None
+              else
+                let costs = Vector.get Cells.table node' in
+                match Tree.pre_classes node' with
+                | [|c_pre'|] when IndexSet.disjoint c_pre' c_pre ->
+                  (* The pre lookahead class does not allow to enter this
+                         branch. *)
+                  None
+                | pre' ->
+                  (* Visit all lookahead classes, pre and post, and find
+                         the mapping between the parent node and this
+                         sub-node *)
+                  let pred_pre _ c_pre' = IndexSet.quick_subset c_pre' c_pre in
+                  let pred_post _ c_post' = IndexSet.quick_subset c_post c_post' in
+                  match
+                  Misc.array_findi pred_pre 0 pre',
+                  Misc.array_findi pred_post 0 (Tree.post_classes node')
+                  with
+                  | exception Not_found -> None
+                  | i_pre', i_post' ->
+                    let offset = Cells.offset node' i_pre' i_post' in
+                    if costs.(offset) = current_cost then
+                      (* We found a candidate of minimal cost *)
+                      Some (Cells.encode_offset node' offset)
+                    else
+                      None
+            ) non_nullable
+            with
+            | None ->
+              Printf.eprintf "abort, cost = %d\n%!" current_cost;
+              assert false
+            | Some cell' ->
+              (* Solve the sub-node *)
+              prepend_word cell' acc
+        end
+    | R (l, r) ->
+      (* It is an inner node.
+         We decompose the problem in a left-hand and a right-hand
+         sub-problems, and find sub-solutions of minimal cost *)
+      let current_cost = Cells.cost cell in
+      let coercion =
+        Coercion.infix (Tree.post_classes l) (Tree.pre_classes r)
+      in
+      let l_index = Cells.encode l in
+      let r_index = Cells.encode r in
+      begin try
+        Array.iteri (fun i_post_l all_pre_r ->
+          let l_cost = Cells.cost (l_index i_pre i_post_l) in
+          Array.iter (fun i_pre_r ->
+            let r_cost = Cells.cost (r_index i_pre_r i_post) in
+            if l_cost + r_cost = current_cost then (
+              let acc = prepend_word (r_index i_pre_r i_post) acc in
+              let acc = prepend_word (l_index i_pre i_post_l) acc in
+              raise (Break acc)
+            )
+          ) all_pre_r
+        ) coercion.Coercion.forward;
+        assert false
+      with Break acc -> acc
+        end
+end
+
+module Form_generator : sig
+  type t
+  val top : Lrc.t -> t
+  val reduce : potential:Lrc.set -> length:int -> t -> t
+  val finish : t -> Lrc.set list
+end = struct
+  type t = {
+    stack: Lrc.set list;
+    potential: Lrc.set;
+    pushed: int;
+  }
+
+  let top lrc = { stack = []; potential = IndexSet.singleton lrc; pushed = 0 }
+
+  let reduce ~potential ~length t =
+    let pushed = t.pushed - length in
+    if pushed >= 0
+    then (
+      assert (
+        if pushed > 0
+        then IndexSet.equal potential t.potential
+        else IndexSet.subset potential t.potential
+      );
+      {t with pushed = pushed + 1; potential}
+    )
+    else (
+      let rec expand acc lrcs = function
+        | 1 -> acc
+        | n ->
+          let lrcs = Misc.indexset_bind lrcs Lrc.predecessors in
+          expand (lrcs :: acc) lrcs (n - 1)
+      in
+      let rec narrow lrcs = function
+        | [] -> t.stack
+        | x :: xs ->
+          let lrcs = Misc.indexset_bind lrcs Lrc.successors in
+          IndexSet.inter x lrcs :: narrow lrcs xs
+      in
+      let stack = narrow potential (expand [t.potential] t.potential (- pushed)) in
+      {potential; stack; pushed = 1}
+    )
+
+  let finish t =
+    if IndexSet.is_empty t.potential
+    then t.stack
+    else t.potential :: t.stack
+end
+
+module Coverage = struct
+  open Info
+  include Mid.Coverage_tree.Make (struct
+    include Reach
+    type terminal = Terminal.n
+    type transition = Reduction.t
+    let initials f = IndexMap.iter (fun _ st -> f st) Reach.initial
+    let successors st f =
+      Reach.iter_targets
+        (Vector.get Reach.states st).transitions
+        (fun (st', red) -> f red st')
+  end)
+
+  let lr1_of state =
+    match Reach.Source.prj (Vector.get Reach.states state).config.source with
+    | L viable -> (Viable.get_config viable).top
+    | R lrc -> Lrc.lr1_of_lrc lrc
+
+  let items_from_suffix suffix =
+    let items_of_state state = Lr1.items (lr1_of state) in
+    let rec loop acc = function
+      | Step (state, _, next) ->
+        loop (items_of_state state :: acc) next
+      | Init state ->
+        items_of_state state :: acc
+    in
+    loop [] suffix
+
+  let form_from_suffix suffix =
+    let get_lrcs state = (Vector.get Reach.states state).config.lrcs in
+    let rec loop = function
+      | Init state ->
+        Form_generator.top
+          (Lrc.first_lrc_of_lr1 (lr1_of state))
+      | Step (state, red, suffix) ->
+        Form_generator.reduce (loop suffix)
+          ~potential:(get_lrcs state)
+          ~length:(Production.length (Reduction.production red))
+    in
+    Form_generator.finish (loop suffix)
+  let get_entrypoint lrc =
+    Nonterminal.to_string
+      (Option.get (Lr0.entrypoint (Lr1.to_lr0 (Lrc.lr1_of_lrc lrc))))
+
+  let rec select_one = function
+    | [] -> []
+    | [x] -> [IndexSet.choose x]
+    | x :: y :: ys ->
+      let x = IndexSet.choose x in
+      x :: select_one (IndexSet.inter (Lrc.successors x) y :: ys)
+
+  let output_terminal oc t =
+    output_char oc ' ';
+    output_string oc (Terminal.to_string t)
+
+  let output_item oc (prod, dot) =
+    output_string oc " /";
+    output_string oc (Nonterminal.to_string (Production.lhs prod));
+    output_char oc ':';
+    let rhs = Production.rhs prod in
+    for i = 0 to dot - 1 do
+      output_char oc ' ';
+      output_string oc (Symbol.name rhs.(i));
+    done;
+    output_string oc " .";
+    for i = dot to Array.length rhs - 1 do
+      output_char oc ' ';
+      output_string oc (Symbol.name rhs.(i));
+    done
+
+  let output_items oc items =
+    output_string oc " [";
+    List.iter (output_item oc) items;
+    output_string oc " ]"
+
+  let output_sentence oc suffix lookaheads =
+    let lrcs = select_one (form_from_suffix suffix) in
+    let lrcs = List.rev_append (lrc_prefix (List.hd lrcs)) lrcs in
+    let entrypoint = get_entrypoint (List.hd lrcs) in
+    let entrypoint = String.sub entrypoint 0 (String.length entrypoint - 1) in
+    let cells = Sentence_gen.cells_of_lrc_list lrcs in
+    let word = List.fold_right Sentence_gen.prepend_word cells [] in
+    print_string entrypoint;
+    List.iter (output_terminal oc) word;
+    print_string " @";
+    IndexSet.iter (output_terminal oc) lookaheads;
+    List.iter (output_items oc) (items_from_suffix suffix);
+    print_newline ()
+
+  let () =
+    enum_sentences
+      ~cover:Lr0.n
+      ~index:(fun st -> Lr1.to_lr0 (lr1_of st))
+      (output_sentence stdout)
+end

--- a/src/enum.ml
+++ b/src/enum.ml
@@ -1,383 +1,320 @@
 open Utils
-
-(* Command-line parsing. *)
-
-let opt_grammar_file = ref None
-let opt_verbose = ref false
-
-let usage =
-  Printf.sprintf
-    "lrgrep, a menhir lexer\n\
-     usage: %s [options] <source>"
-    Sys.argv.(0)
-
-let print_version_num () =
-  print_endline "0.1";
-  exit 0
-
-let print_version_string () =
-  print_string "The Menhir parser lexer generator :-], version ";
-  print_version_num ()
-
-let error {Front.Syntax. line; col} fmt =
-  Printf.eprintf "Error line %d, column %d: " line col;
-  Printf.kfprintf (fun oc -> output_char oc '\n'; flush oc; exit 1) stderr fmt
-
-let warn {Front.Syntax. line; col} fmt =
-  Printf.eprintf "Warning line %d, column %d: " line col;
-  Printf.kfprintf (fun oc -> output_char oc '\n'; flush oc) stderr fmt
-
-let eprintf = Printf.eprintf
-
-let specs = [
-  "-g", Arg.String (fun x -> opt_grammar_file := Some x),
-  " <file.cmly>  Path of the Menhir compiled grammar to analyse (*.cmly)";
-  "-v", Arg.Set opt_verbose,
-  " Increase output verbosity";
-  "-version", Arg.Unit print_version_string,
-  " Print version and exit";
-  "-vnum", Arg.Unit print_version_num,
-  " Print version number and exit";
-]
-
-let () = Arg.parse specs (fun arg -> failwith ("Unexpected argument: " ^ arg)) usage
-
-let grammar_file = match !opt_grammar_file with
-  | Some filename -> filename
-  | None ->
-    Format.eprintf "No grammar provided (-g), stopping now.\n";
-    Arg.usage specs usage;
-    exit 1
-
-let () = Stopwatch.step Stopwatch.main "Beginning"
-
-module Grammar = MenhirSdk.Cmly_read.Read(struct let filename = grammar_file end)
-
-let () = Stopwatch.step Stopwatch.main "Loaded grammar"
-
-module Info = Mid.Info.Make(Grammar)
-module Viable = Mid.Viable_reductions.Make(Info)()
-module Reachability = Mid.Reachability.Make(Info)()
-
-module RawLrc = Mid.Lrc.Make(Info)(Reachability)
-module Lrc = Mid.Lrc.Close(Info)(RawLrc)(struct let initials =
-  Misc.indexset_bind
-    (IndexSet.init_from_set Info.Lr1.n
-      (fun lr1 -> Option.is_none (Info.Lr1.incoming lr1)))
-    RawLrc.lrcs_of_lr1
-end)
-module Reach = Mid.Reachable_reductions.Make(Info)(Viable)(Lrc)()
-
-(*module Failure =  struct
-  (*module Lrc = Mid.Lrc.Minimize(Info)(Lrc)
-  module Reach = Mid.Reachable_reductions.Make(Info)(Viable)(Lrc)()*)
-  module Failure = Mid.Reachable_reductions.FailureNFA(Info)(Viable)(Lrc)(Reach)()
-end*)
-
 open Fix.Indexing
 
-let lrc_prefix =
-  let table = Vector.make Lrc.n [] in
-  let todo = ref [] in
-  let expand prefix state =
-    match Vector.get table state with
-    | [] ->
-      Vector.set table state prefix;
-      let prefix = state :: prefix in
-      let successors = Lrc.successors state in
-      if not (IndexSet.is_empty successors) then
-        Misc.push todo (successors, prefix)
-    | _ -> ()
-  in
-  let visit (successors, prefix) =
-    IndexSet.iter (expand prefix) successors
-  in
-  let rec loop = function
-    | [] -> ()
-    | other ->
-      todo := [];
-      List.iter visit other;
-      loop !todo
-  in
-  Index.iter Info.Lr1.n (fun lr1 ->
+module Make
+    (Info : Mid.Info.S)
+    (Reachability : Mid.Reachability.S with module Info := Info)
+    (Viable : Mid.Viable_reductions.S with module Info := Info)
+    (Lrc : Mid.Lrc.S with module Info := Info)
+    (Reach : Mid.Reachable_reductions.S
+     with module Info := Info
+      and module Viable := Viable
+      and module Lrc := Lrc)
+=
+struct
+  let lrc_prefix =
+    let table = Vector.make Lrc.n [] in
+    let todo = ref [] in
+    let expand prefix state =
+      match Vector.get table state with
+      | [] ->
+        Vector.set table state prefix;
+        let prefix = state :: prefix in
+        let successors = Lrc.successors state in
+        if not (IndexSet.is_empty successors) then
+          Misc.push todo (successors, prefix)
+      | _ -> ()
+    in
+    let visit (successors, prefix) =
+      IndexSet.iter (expand prefix) successors
+    in
+    let rec loop = function
+      | [] -> ()
+      | other ->
+        todo := [];
+        List.iter visit other;
+        loop !todo
+    in
+    Index.iter Info.Lr1.n (fun lr1 ->
       if Option.is_none (Info.Lr1.incoming lr1) then
         expand [] (Lrc.first_lrc_of_lr1 lr1)
     );
-  loop !todo;
-  Vector.get table
+    loop !todo;
+    Vector.get table
 
-module Sentence_gen =
-struct
-  open Info
+  module Sentence_gen =
+  struct
+    open Info
 
-  let rec cells_of_lrc_list = function
-    | [] -> assert false
-    | [_] ->  []
-    | (x :: (y :: _ as tail)) ->
-      let xl = Lrc.lr1_of_lrc x in
-      let yl = Lrc.lr1_of_lrc y in
-      let yi = Lrc.class_index y in
-      let tr =
-        List.find
-          (fun tr -> Transition.source tr = xl)
-          (Transition.predecessors yl)
-      in
+    let rec cells_of_lrc_list = function
+      | [] -> assert false
+      | [_] ->  []
+      | (x :: (y :: _ as tail)) ->
+        let xl = Lrc.lr1_of_lrc x in
+        let yl = Lrc.lr1_of_lrc y in
+        let yi = Lrc.class_index y in
+        let tr =
+          List.find
+            (fun tr -> Transition.source tr = xl)
+            (Transition.predecessors yl)
+        in
+        let open Reachability in
+        let xi =
+          match Classes.pre_transition tr with
+          | [|c_pre|] when IndexSet.is_singleton c_pre ->
+            if not (IndexSet.subset c_pre (Lrc.lookahead x)) then (
+              Printf.eprintf "pre:%s expected:%s\nfrom:%s to:%s after:%s\n%!"
+                (Misc.string_of_indexset ~index:Terminal.to_string c_pre)
+                (Misc.string_of_indexset ~index:Terminal.to_string (Lrc.lookahead x))
+                (Lr1.to_string xl)
+                (Lr1.to_string yl)
+                (if IndexSet.equal (Lrc.lookahead y) Terminal.all
+                  then "all"
+                  else Misc.string_of_indexset ~index:Terminal.to_string (Lrc.lookahead y))
+              ;
+              assert false
+            );
+            0
+          | _ -> Lrc.class_index x
+        in
+        let yi = (Coercion.infix (Classes.post_transition tr) (Classes.for_lr1 yl)).backward.(yi)
+        in
+        Cells.encode (Tree.leaf tr) xi yi :: cells_of_lrc_list tail
+
+    exception Break of Terminal.t list
+
+    let rec prepend_word cell acc =
       let open Reachability in
-      let xi =
-        match Classes.pre_transition tr with
-        | [|c_pre|] when IndexSet.is_singleton c_pre ->
-          if not (IndexSet.subset c_pre (Lrc.lookahead x)) then (
-            Printf.eprintf "pre:%s expected:%s\nfrom:%s to:%s after:%s\n%!"
-              (Misc.string_of_indexset ~index:Terminal.to_string c_pre)
-              (Misc.string_of_indexset ~index:Terminal.to_string (Lrc.lookahead x))
-              (Lr1.to_string xl)
-              (Lr1.to_string yl)
-              (if IndexSet.equal (Lrc.lookahead y) Terminal.all
-                then "all"
-                else Misc.string_of_indexset ~index:Terminal.to_string (Lrc.lookahead y))
-            ;
-            assert false
-          );
-          0
-        | _ -> Lrc.class_index x
-      in
-      let yi = (Coercion.infix (Classes.post_transition tr) (Classes.for_lr1 yl)).backward.(yi)
-      in
-      Cells.encode (Tree.leaf tr) xi yi :: cells_of_lrc_list tail
-
-  exception Break of Terminal.t list
-
-  let rec prepend_word cell acc =
-    let open Reachability in
-    let node, i_pre, i_post = Cells.decode cell in
-    match Tree.split node with
-    | L tr ->
-      (* The node corresponds to a transition *)
-      begin match Transition.split tr with
-        | R shift ->
-          (* It is a shift transition, just shift the symbol *)
-          Transition.shift_symbol shift :: acc
-        | L goto ->
-          (* It is a goto transition *)
-          let nullable, non_nullable = Tree.goto_equations goto in
-          let c_pre = (Tree.pre_classes node).(i_pre) in
-          let c_post = (Tree.post_classes node).(i_post) in
-          if not (IndexSet.is_empty nullable) &&
-            IndexSet.quick_subset c_post nullable &&
-            not (IndexSet.disjoint c_pre c_post) then
-            (* If a nullable reduction is possible, don't do anything *)
-            acc
-          else
-            (* Otherwise look at all equations that define the cost of the
+      let node, i_pre, i_post = Cells.decode cell in
+      match Tree.split node with
+      | L tr ->
+        (* The node corresponds to a transition *)
+        begin match Transition.split tr with
+          | R shift ->
+            (* It is a shift transition, just shift the symbol *)
+            Transition.shift_symbol shift :: acc
+          | L goto ->
+            (* It is a goto transition *)
+            let nullable, non_nullable = Tree.goto_equations goto in
+            let c_pre = (Tree.pre_classes node).(i_pre) in
+            let c_post = (Tree.post_classes node).(i_post) in
+            if not (IndexSet.is_empty nullable) &&
+              IndexSet.quick_subset c_post nullable &&
+              not (IndexSet.disjoint c_pre c_post) then
+              (* If a nullable reduction is possible, don't do anything *)
+              acc
+            else
+              (* Otherwise look at all equations that define the cost of the
                goto transition and recursively visit one of minimal cost *)
-            let current_cost = Cells.cost cell in
-            match
-            List.find_map (fun (node', lookahead) ->
-              if IndexSet.disjoint c_post lookahead then
-                (* The post lookahead class does not permit reducing this
+              let current_cost = Cells.cost cell in
+              match
+              List.find_map (fun (node', lookahead) ->
+                if IndexSet.disjoint c_post lookahead then
+                  (* The post lookahead class does not permit reducing this
                        production *)
-                None
-              else
-                let costs = Vector.get Cells.table node' in
-                match Tree.pre_classes node' with
-                | [|c_pre'|] when IndexSet.disjoint c_pre' c_pre ->
-                  (* The pre lookahead class does not allow to enter this
-                         branch. *)
                   None
-                | pre' ->
-                  (* Visit all lookahead classes, pre and post, and find
+                else
+                  let costs = Vector.get Cells.table node' in
+                  match Tree.pre_classes node' with
+                  | [|c_pre'|] when IndexSet.disjoint c_pre' c_pre ->
+                    (* The pre lookahead class does not allow to enter this
+                         branch. *)
+                    None
+                  | pre' ->
+                    (* Visit all lookahead classes, pre and post, and find
                          the mapping between the parent node and this
                          sub-node *)
-                  let pred_pre _ c_pre' = IndexSet.quick_subset c_pre' c_pre in
-                  let pred_post _ c_post' = IndexSet.quick_subset c_post c_post' in
-                  match
-                  Misc.array_findi pred_pre 0 pre',
-                  Misc.array_findi pred_post 0 (Tree.post_classes node')
-                  with
-                  | exception Not_found -> None
-                  | i_pre', i_post' ->
-                    let offset = Cells.offset node' i_pre' i_post' in
-                    if costs.(offset) = current_cost then
-                      (* We found a candidate of minimal cost *)
-                      Some (Cells.encode_offset node' offset)
-                    else
-                      None
-            ) non_nullable
-            with
-            | None ->
-              Printf.eprintf "abort, cost = %d\n%!" current_cost;
-              assert false
-            | Some cell' ->
-              (* Solve the sub-node *)
-              prepend_word cell' acc
-        end
-    | R (l, r) ->
-      (* It is an inner node.
+                    let pred_pre _ c_pre' = IndexSet.quick_subset c_pre' c_pre in
+                    let pred_post _ c_post' = IndexSet.quick_subset c_post c_post' in
+                    match
+                    Misc.array_findi pred_pre 0 pre',
+                    Misc.array_findi pred_post 0 (Tree.post_classes node')
+                    with
+                    | exception Not_found -> None
+                    | i_pre', i_post' ->
+                      let offset = Cells.offset node' i_pre' i_post' in
+                      if costs.(offset) = current_cost then
+                        (* We found a candidate of minimal cost *)
+                        Some (Cells.encode_offset node' offset)
+                      else
+                        None
+              ) non_nullable
+              with
+              | None ->
+                Printf.eprintf "abort, cost = %d\n%!" current_cost;
+                assert false
+              | Some cell' ->
+                (* Solve the sub-node *)
+                prepend_word cell' acc
+          end
+      | R (l, r) ->
+        (* It is an inner node.
          We decompose the problem in a left-hand and a right-hand
          sub-problems, and find sub-solutions of minimal cost *)
-      let current_cost = Cells.cost cell in
-      let coercion =
-        Coercion.infix (Tree.post_classes l) (Tree.pre_classes r)
+        let current_cost = Cells.cost cell in
+        let coercion =
+          Coercion.infix (Tree.post_classes l) (Tree.pre_classes r)
+        in
+        let l_index = Cells.encode l in
+        let r_index = Cells.encode r in
+        begin try
+          Array.iteri (fun i_post_l all_pre_r ->
+            let l_cost = Cells.cost (l_index i_pre i_post_l) in
+            Array.iter (fun i_pre_r ->
+              let r_cost = Cells.cost (r_index i_pre_r i_post) in
+              if l_cost + r_cost = current_cost then (
+                let acc = prepend_word (r_index i_pre_r i_post) acc in
+                let acc = prepend_word (l_index i_pre i_post_l) acc in
+                raise (Break acc)
+              )
+            ) all_pre_r
+          ) coercion.Coercion.forward;
+          assert false
+        with Break acc -> acc
+          end
+  end
+
+  module Form_generator : sig
+    type t
+    val top : Lrc.t -> t
+    val reduce : potential:Lrc.set -> length:int -> t -> t
+    val finish : t -> Lrc.set list
+  end = struct
+    type t = {
+      stack: Lrc.set list;
+      potential: Lrc.set;
+      pushed: int;
+    }
+
+    let top lrc = { stack = []; potential = IndexSet.singleton lrc; pushed = 0 }
+
+    let reduce ~potential ~length t =
+      let pushed = t.pushed - length in
+      if pushed >= 0
+      then (
+        assert (
+          if pushed > 0
+          then IndexSet.equal potential t.potential
+          else IndexSet.subset potential t.potential
+        );
+        {t with pushed = pushed + 1; potential}
+      )
+      else (
+        let rec expand acc lrcs = function
+          | 1 -> acc
+          | n ->
+            let lrcs = Misc.indexset_bind lrcs Lrc.predecessors in
+            expand (lrcs :: acc) lrcs (n - 1)
+        in
+        let rec narrow lrcs = function
+          | [] -> t.stack
+          | x :: xs ->
+            let lrcs = Misc.indexset_bind lrcs Lrc.successors in
+            IndexSet.inter x lrcs :: narrow lrcs xs
+        in
+        let stack = narrow potential (expand [t.potential] t.potential (- pushed)) in
+        {potential; stack; pushed = 1}
+      )
+
+    let finish t =
+      if IndexSet.is_empty t.potential
+      then t.stack
+      else t.potential :: t.stack
+  end
+
+  module Coverage = struct
+    open Info
+    include Mid.Coverage_tree.Make (struct
+      include Reach
+      type terminal = Terminal.n
+      type transition = Reduction.t
+      let initials f = IndexMap.iter (fun _ st -> f st) Reach.initial
+      let successors st f =
+        Reach.iter_targets
+          (Vector.get Reach.states st).transitions
+          (fun (st', red) -> f red st')
+    end)
+
+    let lr1_of state =
+      match Reach.Source.prj (Vector.get Reach.states state).config.source with
+      | L viable -> (Viable.get_config viable).top
+      | R lrc -> Lrc.lr1_of_lrc lrc
+
+    let items_from_suffix suffix =
+      let items_of_state state = Lr1.items (lr1_of state) in
+      let rec loop acc = function
+        | Step (state, _, next) ->
+          loop (items_of_state state :: acc) next
+        | Init state ->
+          items_of_state state :: acc
       in
-      let l_index = Cells.encode l in
-      let r_index = Cells.encode r in
-      begin try
-        Array.iteri (fun i_post_l all_pre_r ->
-          let l_cost = Cells.cost (l_index i_pre i_post_l) in
-          Array.iter (fun i_pre_r ->
-            let r_cost = Cells.cost (r_index i_pre_r i_post) in
-            if l_cost + r_cost = current_cost then (
-              let acc = prepend_word (r_index i_pre_r i_post) acc in
-              let acc = prepend_word (l_index i_pre i_post_l) acc in
-              raise (Break acc)
-            )
-          ) all_pre_r
-        ) coercion.Coercion.forward;
-        assert false
-      with Break acc -> acc
-        end
-end
+      loop [] suffix
 
-module Form_generator : sig
-  type t
-  val top : Lrc.t -> t
-  val reduce : potential:Lrc.set -> length:int -> t -> t
-  val finish : t -> Lrc.set list
-end = struct
-  type t = {
-    stack: Lrc.set list;
-    potential: Lrc.set;
-    pushed: int;
-  }
-
-  let top lrc = { stack = []; potential = IndexSet.singleton lrc; pushed = 0 }
-
-  let reduce ~potential ~length t =
-    let pushed = t.pushed - length in
-    if pushed >= 0
-    then (
-      assert (
-        if pushed > 0
-        then IndexSet.equal potential t.potential
-        else IndexSet.subset potential t.potential
-      );
-      {t with pushed = pushed + 1; potential}
-    )
-    else (
-      let rec expand acc lrcs = function
-        | 1 -> acc
-        | n ->
-          let lrcs = Misc.indexset_bind lrcs Lrc.predecessors in
-          expand (lrcs :: acc) lrcs (n - 1)
+    let form_from_suffix suffix =
+      let get_lrcs state = (Vector.get Reach.states state).config.lrcs in
+      let rec loop = function
+        | Init state ->
+          Form_generator.top
+            (Lrc.first_lrc_of_lr1 (lr1_of state))
+        | Step (state, red, suffix) ->
+          Form_generator.reduce (loop suffix)
+            ~potential:(get_lrcs state)
+            ~length:(Production.length (Reduction.production red))
       in
-      let rec narrow lrcs = function
-        | [] -> t.stack
-        | x :: xs ->
-          let lrcs = Misc.indexset_bind lrcs Lrc.successors in
-          IndexSet.inter x lrcs :: narrow lrcs xs
-      in
-      let stack = narrow potential (expand [t.potential] t.potential (- pushed)) in
-      {potential; stack; pushed = 1}
-    )
+      Form_generator.finish (loop suffix)
+    let get_entrypoint lrc =
+      Nonterminal.to_string
+        (Option.get (Lr0.entrypoint (Lr1.to_lr0 (Lrc.lr1_of_lrc lrc))))
 
-  let finish t =
-    if IndexSet.is_empty t.potential
-    then t.stack
-    else t.potential :: t.stack
-end
+    let rec select_one = function
+      | [] -> []
+      | [x] -> [IndexSet.choose x]
+      | x :: y :: ys ->
+        let x = IndexSet.choose x in
+        x :: select_one (IndexSet.inter (Lrc.successors x) y :: ys)
 
-module Coverage = struct
-  open Info
-  include Mid.Coverage_tree.Make (struct
-    include Reach
-    type terminal = Terminal.n
-    type transition = Reduction.t
-    let initials f = IndexMap.iter (fun _ st -> f st) Reach.initial
-    let successors st f =
-      Reach.iter_targets
-        (Vector.get Reach.states st).transitions
-        (fun (st', red) -> f red st')
-  end)
-
-  let lr1_of state =
-    match Reach.Source.prj (Vector.get Reach.states state).config.source with
-    | L viable -> (Viable.get_config viable).top
-    | R lrc -> Lrc.lr1_of_lrc lrc
-
-  let items_from_suffix suffix =
-    let items_of_state state = Lr1.items (lr1_of state) in
-    let rec loop acc = function
-      | Step (state, _, next) ->
-        loop (items_of_state state :: acc) next
-      | Init state ->
-        items_of_state state :: acc
-    in
-    loop [] suffix
-
-  let form_from_suffix suffix =
-    let get_lrcs state = (Vector.get Reach.states state).config.lrcs in
-    let rec loop = function
-      | Init state ->
-        Form_generator.top
-          (Lrc.first_lrc_of_lr1 (lr1_of state))
-      | Step (state, red, suffix) ->
-        Form_generator.reduce (loop suffix)
-          ~potential:(get_lrcs state)
-          ~length:(Production.length (Reduction.production red))
-    in
-    Form_generator.finish (loop suffix)
-  let get_entrypoint lrc =
-    Nonterminal.to_string
-      (Option.get (Lr0.entrypoint (Lr1.to_lr0 (Lrc.lr1_of_lrc lrc))))
-
-  let rec select_one = function
-    | [] -> []
-    | [x] -> [IndexSet.choose x]
-    | x :: y :: ys ->
-      let x = IndexSet.choose x in
-      x :: select_one (IndexSet.inter (Lrc.successors x) y :: ys)
-
-  let output_terminal oc t =
-    output_char oc ' ';
-    output_string oc (Terminal.to_string t)
-
-  let output_item oc (prod, dot) =
-    output_string oc " /";
-    output_string oc (Nonterminal.to_string (Production.lhs prod));
-    output_char oc ':';
-    let rhs = Production.rhs prod in
-    for i = 0 to dot - 1 do
+    let output_terminal oc t =
       output_char oc ' ';
-      output_string oc (Symbol.name rhs.(i));
-    done;
-    output_string oc " .";
-    for i = dot to Array.length rhs - 1 do
-      output_char oc ' ';
-      output_string oc (Symbol.name rhs.(i));
-    done
+      output_string oc (Terminal.to_string t)
 
-  let output_items oc items =
-    output_string oc " [";
-    List.iter (output_item oc) items;
-    output_string oc " ]"
+    let output_item oc (prod, dot) =
+      output_string oc " /";
+      output_string oc (Nonterminal.to_string (Production.lhs prod));
+      output_char oc ':';
+      let rhs = Production.rhs prod in
+      for i = 0 to dot - 1 do
+        output_char oc ' ';
+        output_string oc (Symbol.name rhs.(i));
+      done;
+      output_string oc " .";
+      for i = dot to Array.length rhs - 1 do
+        output_char oc ' ';
+        output_string oc (Symbol.name rhs.(i));
+      done
 
-  let output_sentence oc suffix lookaheads =
-    let lrcs = select_one (form_from_suffix suffix) in
-    let lrcs = List.rev_append (lrc_prefix (List.hd lrcs)) lrcs in
-    let entrypoint = get_entrypoint (List.hd lrcs) in
-    let entrypoint = String.sub entrypoint 0 (String.length entrypoint - 1) in
-    let cells = Sentence_gen.cells_of_lrc_list lrcs in
-    let word = List.fold_right Sentence_gen.prepend_word cells [] in
-    print_string entrypoint;
-    List.iter (output_terminal oc) word;
-    print_string " @";
-    IndexSet.iter (output_terminal oc) lookaheads;
-    List.iter (output_items oc) (items_from_suffix suffix);
-    print_newline ()
+    let output_items oc items =
+      output_string oc " [";
+      List.iter (output_item oc) items;
+      output_string oc " ]"
 
-  let () =
-    enum_sentences
-      ~cover:Lr0.n
-      ~index:(fun st -> Lr1.to_lr0 (lr1_of st))
-      (output_sentence stdout)
+    let output_sentence oc suffix lookaheads =
+      let lrcs = select_one (form_from_suffix suffix) in
+      let lrcs = List.rev_append (lrc_prefix (List.hd lrcs)) lrcs in
+      let entrypoint = get_entrypoint (List.hd lrcs) in
+      let entrypoint = String.sub entrypoint 0 (String.length entrypoint - 1) in
+      let cells = Sentence_gen.cells_of_lrc_list lrcs in
+      let word = List.fold_right Sentence_gen.prepend_word cells [] in
+      print_string entrypoint;
+      List.iter (output_terminal oc) word;
+      print_string " @";
+      IndexSet.iter (output_terminal oc) lookaheads;
+      List.iter (output_items oc) (items_from_suffix suffix);
+      print_newline ()
+
+    let () =
+      enum_sentences
+        ~cover:Lr0.n
+        ~index:(fun st -> Lr1.to_lr0 (lr1_of st))
+        (output_sentence stdout)
+  end
 end

--- a/src/main.ml
+++ b/src/main.ml
@@ -217,15 +217,6 @@ let process_entry oc (entry : Front.Syntax.entry) = (
   Printf.eprintf "Min DFA states: %d\n" (cardinal MinDFA.states);
   Printf.eprintf "Output DFA states: %d\n" (cardinal OutDFA.states);
   Printf.eprintf "Time spent: %.02fms\n" (Sys.time () *. 1000.);
-  let unhandled = ref 0 in
-  Index.iter OutDFA.states (fun state ->
-      if not (IndexSet.is_empty (OutDFA.unhandled state)) then
-        incr unhandled;
-    );
-  Printf.eprintf "states with unhandled transitions: %d\n%!" !unhandled;
-  (*let module Coverage =
-    Mid.Coverage.Make(Info)(OutDFA)(Lrc.Lrce)
-  in*)
   let get_state_for_compaction index =
     let add_match (clause, priority, regs) =
       let cap = captures clause in

--- a/src/main.ml
+++ b/src/main.ml
@@ -422,8 +422,8 @@ let () =
           (output stdout)
       | Enum_lr1 ->
         Enum.enumerate
-          ~cover:Info.Lr0.n
-          ~index:(fun x -> Info.Lr1.to_lr0 (Enum.Coverage.lr1_of x))
+          ~cover:Info.Lr1.n
+          ~index:(fun x -> Enum.Coverage.lr1_of x)
           (output stdout)
       | Enum_goto ->
         Enum.enumerate

--- a/src/mid/coverage_tree.ml
+++ b/src/mid/coverage_tree.ml
@@ -1,0 +1,162 @@
+open Utils
+open Misc
+open Fix.Indexing
+
+module Make (Graph : sig
+    include CARDINAL
+    type terminal
+    type transition
+    val initials : (n index -> unit) -> unit
+    val successors : n index -> (transition -> n index -> unit) -> unit
+    val rejected : n index -> terminal indexset
+    val potential_reject : n index -> terminal indexset
+  end) :
+sig
+  type suffix =
+    | Init of Graph.n index
+    | Step of Graph.n index * Graph.transition * suffix
+
+  val enum_sentences :
+    cover:'n cardinal -> index:(Graph.n index -> 'n index) ->
+    (suffix -> Graph.terminal indexset -> unit) -> unit
+end =
+struct
+  type suffix =
+    | Init of Graph.n index
+    | Step of Graph.n index * Graph.transition * suffix
+
+  type node = {
+    suffix: suffix;
+    mutable committed: Graph.terminal indexset;
+    mutable child: node list;
+  }
+
+  let suffix_state (Init st | Step (st, _, _)) = st
+
+  let remainings ~cover ~index =
+    let table = Vector.make cover IndexSet.empty in
+    Index.iter Graph.n (fun st ->
+        let i = index st in
+        let set = Vector.get table i in
+        Vector.set table i
+          (IndexSet.union (Graph.potential_reject st) set)
+      );
+    table
+
+  let build_arborescence ~cover ~index =
+    let remainings = remainings ~cover ~index in
+    let visited = Boolvector.make Graph.n in
+    let todo = ref [] in
+    let need_visit st =
+      if not (Boolvector.test visited st)
+      then (Boolvector.set visited st; true)
+      else false
+    in
+    let visit_node node =
+      let st = suffix_state node.suffix in
+      let i = index st in
+      let remaining = Vector.get remainings i in
+      node.committed <- IndexSet.inter remaining (Graph.rejected st);
+      Vector.set remainings i (IndexSet.diff remaining node.committed);
+      Graph.successors st (fun transition st' ->
+          if need_visit st' then (
+            let node' = {
+              suffix = Step (st', transition, node.suffix);
+              committed = IndexSet.empty;
+              child = [];
+            } in
+            node.child <- node' :: node.child;
+            Misc.push todo node'
+          )
+        )
+    in
+    let initials = ref [] in
+    Graph.initials (fun st ->
+        assert (need_visit st);
+        let node = {
+          suffix = Init st;
+          committed = IndexSet.empty;
+          child = [];
+        } in
+        visit_node node;
+        Misc.push initials node
+      );
+    let initials = !initials in
+    while !todo <> [] do
+      let todo' = !todo in
+      todo := [];
+      List.iter visit_node todo'
+    done;
+    (remainings, initials)
+
+  let build_remainder remaining suffix =
+    let remaining = ref remaining in
+    let todo = ref [] in
+    let visit node =
+      let st = suffix_state node.suffix in
+      node.committed <- IndexSet.inter !remaining (Graph.rejected st);
+      if not (IndexSet.is_empty node.committed) then
+        remaining := IndexSet.diff !remaining node.committed;
+      Graph.successors st @@ fun transition st' ->
+      if not (IndexSet.disjoint !remaining (Graph.potential_reject st)) then (
+        let node' = {
+          suffix = Step (st', transition, node.suffix);
+          committed = IndexSet.empty;
+          child = [];
+        } in
+        node.child <- node' :: node.child;
+        Misc.push todo node'
+      )
+    in
+    let root = {suffix; committed = IndexSet.empty; child = []} in
+    visit root;
+    while !todo <> [] do
+      let todo' = !todo in
+      todo := [];
+      List.iter visit todo'
+    done;
+    root
+
+  let enum_sentences ~cover ~index f =
+    let remainings, forest = build_arborescence ~cover ~index in
+    let visited = Boolvector.make Graph.n in
+    let rec visit in_remainder node =
+      let processed =
+        List.fold_left
+          (fun acc node -> IndexSet.union (visit in_remainder node) acc)
+          IndexSet.empty node.child
+      in
+      let processed =
+        let remainder = IndexSet.diff node.committed processed in
+        if IndexSet.is_empty remainder then processed else (
+          f node.suffix remainder;
+          IndexSet.union remainder processed
+        )
+      in
+      let processed =
+        let state = suffix_state node.suffix in
+        Boolvector.set visited state;
+        let index = index state in
+        let remaining = Vector.get remainings index in
+        if in_remainder then (
+          let remaining' = IndexSet.diff remaining processed in
+          if remaining != remaining' then
+            Vector.set remainings index remaining';
+          processed
+        ) else
+          let remainder =
+            IndexSet.inter remaining (Graph.potential_reject state)
+          in
+          if IndexSet.is_empty remainder then processed else (
+            let node' = build_remainder remainder node.suffix in
+            let remainder' = visit true node' in
+            assert (IndexSet.subset remainder remainder');
+            assert (IndexSet.disjoint (Vector.get remainings index) remainder);
+            IndexSet.union remainder' processed
+          )
+      in
+      processed
+    in
+    List.iter (fun node -> ignore (visit false node)) forest;
+    Vector.iter (fun set -> assert (IndexSet.is_empty set)) remainings
+end

--- a/src/mid/reachable_reductions.ml
+++ b/src/mid/reachable_reductions.ml
@@ -1,0 +1,216 @@
+open Utils
+open Misc
+open Fix.Indexing
+
+module type S = sig
+  module Info : Info.S
+  module Viable: Viable_reductions.S with module Info := Info
+  module Lrc : Lrc.S with module Info := Info
+  open Info
+
+  include CARDINAL
+
+  module Source : SUM with type l := Viable.n and type r := Lrc.n
+
+  type config = {
+    source: Source.n index;
+    lrcs : Lrc.set;
+    accepted: Terminal.set;
+    rejected: Terminal.set;
+  }
+
+  type target = n index * Reduction.t
+
+  type transitions = {
+    inner: target list;
+    outer: target list list;
+  }
+
+  type desc = {
+    config: config;
+    transitions: transitions;
+  }
+
+  val initial : n index Lrc.map
+  val states : (n, desc) vector
+
+  val successors : (n, n indexset) vector
+  val predecessors : (n, n indexset) vector
+
+  val accepted : n index -> Terminal.set
+  val rejected : n index -> Terminal.set
+  val potential_reject : n index -> Terminal.set
+
+  val iter_targets : transitions -> (target -> unit) -> unit
+  val rev_iter_targets : transitions -> (target -> unit) -> unit
+  val fold_targets : ('a -> target -> 'a) -> 'a -> transitions -> 'a
+  val rev_fold_targets : (target -> 'a -> 'a) -> transitions -> 'a -> 'a
+end
+
+module Make
+    (Info : Info.S)
+    (Viable: Viable_reductions.S with module Info := Info)
+    (Lrc: Lrc.S with module Info := Info)
+    () : S with module Info := Info
+            and module Viable := Viable
+            and module Lrc := Lrc
+=
+struct
+  open Info
+  let time = Stopwatch.enter Stopwatch.main "Reachable reductions (3)"
+
+  module Source = Sum(Viable)(Lrc)
+
+  include IndexBuffer.Gen.Make()
+
+  type config = {
+    source: Source.n index;
+    lrcs : Lrc.set;
+    accepted: Terminal.set;
+    rejected: Terminal.set;
+  }
+
+  type target = n index * Reduction.t
+
+  type transitions = {
+    inner: target list;
+    outer: target list list;
+  }
+
+  type desc = {
+    config: config;
+    transitions: transitions;
+  }
+
+  let states = get_generator ()
+
+  let nodes = Hashtbl.create 7
+
+  let make_config ~accepted ~rejected lrcs source =
+    let lr1 =
+      match Source.prj source with
+      | L viable -> (Viable.get_config viable).top
+      | R lrc -> Lrc.lr1_of_lrc lrc
+    in
+    let a =
+      IndexSet.union accepted
+        (IndexSet.diff (Lr1.shift_on lr1) rejected)
+    and r =
+      IndexSet.union rejected
+        (IndexSet.diff (Lr1.reject lr1) accepted)
+    in
+    {accepted=a; rejected=r; source; lrcs}
+
+  let rec visit_config ~accepted ~rejected lrcs source =
+    let config = make_config ~accepted ~rejected lrcs source in
+    match Hashtbl.find_opt nodes config with
+    | Some state -> state
+    | None ->
+      let reservation = IndexBuffer.Gen.reserve states in
+      let index = IndexBuffer.Gen.index reservation in
+      Hashtbl.add nodes config index;
+      let {accepted; rejected; source; lrcs} = config in
+      let transitions =
+        match Source.prj source with
+        | L viable ->
+          visit_transitions ~accepted ~rejected lrcs
+            (Viable.get_transitions viable)
+        | R lrc ->
+          match Vector.get Viable.initial (Lrc.lr1_of_lrc lrc) with
+          | [] -> {inner=[]; outer=[]}
+          | outer0 :: outer ->
+            {inner=[]; outer=visit_outer ~accepted ~rejected lrcs outer0 outer}
+      in
+      IndexBuffer.Gen.commit states reservation {config; transitions};
+      index
+
+  and visit_transitions ~accepted ~rejected lrcs {Viable.inner; outer} =
+    (*let  = Viable.get_transitions config.viable in*)
+    let inner =
+      List.fold_left (fun acc {Viable.candidates; _} ->
+        List.fold_left
+          (fun acc {Viable.target; lookahead=_; filter=(); reduction} ->
+            let state = visit_config ~accepted ~rejected lrcs (Source.inj_l target) in
+            (state, reduction) :: acc)
+          acc candidates
+      ) [] inner
+    in
+    let outer = match outer with
+      | first :: rest -> visit_outer ~accepted ~rejected lrcs first rest
+      | [] -> []
+    in
+    {inner; outer}
+
+  and visit_outer ~accepted ~rejected lrcs {Viable.candidates; _} rest =
+    let visit_candidate {Viable.target; lookahead=_; filter=lr1s; reduction} =
+      let compatible_lrc lr1 = IndexSet.inter lrcs (Lrc.lrcs_of_lr1 lr1) in
+      let lrcs = indexset_bind lr1s compatible_lrc in
+      if IndexSet.is_empty lrcs
+      then None
+      else Some (visit_config ~accepted ~rejected lrcs (Source.inj_l target), reduction)
+    in
+    let candidates = List.filter_map visit_candidate candidates in
+    match rest with
+    | [] -> [candidates]
+    | next :: rest ->
+      candidates ::
+      visit_outer ~accepted ~rejected (indexset_bind lrcs Lrc.predecessors) next rest
+
+  let initial =
+    let process lrc =
+      let lr1 = Lrc.lr1_of_lrc lrc in
+      let accepted = Lr1.shift_on lr1 in
+      let rejected = Lr1.reject lr1 in
+      visit_config ~accepted ~rejected
+        (IndexSet.singleton lrc)
+        (Source.inj_r lrc)
+    in
+    IndexMap.inflate process Lrc.idle
+
+  let states = IndexBuffer.Gen.freeze states
+
+  let () = Stopwatch.step time "Nodes: %d" (cardinal n)
+
+  let iter_targets {inner; outer} f =
+    List.iter f inner;
+    List.iter (List.iter f) outer
+
+  let rev_iter_targets {inner; outer} f =
+    list_rev_iter f inner;
+    list_rev_iter (list_rev_iter f) outer
+
+  let fold_targets f acc {inner; outer} =
+    let acc = List.fold_left f acc inner in
+    let acc = List.fold_left (List.fold_left f) acc outer in
+    acc
+
+  let rev_fold_targets f {inner; outer} acc =
+    let acc = List.fold_right f inner acc in
+    let acc = List.fold_right (List.fold_right f) outer acc in
+    acc
+
+  let successors =
+    Vector.map (fun desc ->
+        rev_fold_targets
+          (fun (st, _) acc -> IndexSet.add st acc)
+          desc.transitions IndexSet.empty
+      ) states
+
+  let predecessors =
+    Misc.relation_reverse successors
+
+  let accepted st = (Vector.get states st).config.accepted
+  let rejected st = (Vector.get states st).config.rejected
+
+  let potential_reject =
+    let table = Vector.init n rejected in
+    let widen _src rej1 _tgt rej2 =
+      (*assert (IndexSet.disjoint rej1 (accepted tgt));*)
+      IndexSet.union rej1 rej2
+    in
+    Misc.fixpoint predecessors table ~propagate:widen;
+    Vector.get table
+
+  let () = Stopwatch.leave time
+
+end

--- a/src/utils/boolvector.ml
+++ b/src/utils/boolvector.ml
@@ -1,0 +1,27 @@
+open Fix.Indexing
+
+type 'n t = bytes
+
+let make c =
+  let n = cardinal c in
+  Bytes.make ((n + 7) lsr 3) '\000'
+
+let test b n =
+  let n = (n : _ index :> int) in
+  let cell = n lsr 3 in
+  let bit = n land 7 in
+  Char.code (Bytes.unsafe_get b cell) land (1 lsl bit) <> 0
+
+let set b n =
+  let n = (n : _ index :> int) in
+  let cell = n lsr 3 in
+  let bit = n land 7 in
+  Bytes.unsafe_set b cell
+    (Char.unsafe_chr (Char.code (Bytes.unsafe_get b cell) lor (1 lsl bit)))
+
+let clear b n =
+  let n = (n : _ index :> int) in
+  let cell = n lsr 3 in
+  let bit = n land 7 in
+  Bytes.unsafe_set b cell
+    (Char.unsafe_chr (Char.code (Bytes.unsafe_get b cell) land lnot (1 lsl bit)))

--- a/src/utils/boolvector.mli
+++ b/src/utils/boolvector.mli
@@ -1,0 +1,8 @@
+open Fix.Indexing
+
+type 'n t
+
+val make : 'n cardinal -> 'n t
+val test : 'n t -> 'n index -> bool
+val set : 'n t -> 'n index -> unit
+val clear : 'n t -> 'n index -> unit


### PR DESCRIPTION
This PR adds a feature to enumerate sentence to fuzz a grammar/parser:
```
lrgrep, a menhir lexer
usage: lrgrep [options] <source>
...
  -enumerate  <lr0|lr1|goto>
        Enumerate sentences to cover failing configurations
  -enumerate-format  <raw|json> 
        Format used to output enumeration
...
No grammar provided (-g), stopping now.
```

It is activated by passing `-enumerate lr0` (or `lr1` or `goto`). lrgrep will output many lines, each representing a "sentence group".

# Example

For instance, running it on OCaml grammar with `lrgrep -g ./_build/default/ocaml/parser_raw.cmly -enumerate lr0` outputs many lines like:

```
...
implementation BACKQUOTE UIDENT @ error WHILE WHEN VIRTUAL UNDERSCORE TRY STRUCT SIG REC QUOTE PRIVATE OF OBJECT NONREC MUTABLE MATCH LETOP LESSMINUS LBRACKETLESS LBRACKETGREATER LAZY IF FUNCTOR FUNCTION FUN FO
R DOTDOT DOCSTRING COMMENT ASSERT AS # [ /ident: UIDENT . ] [ /name_tag: BACKQUOTE ident . ] [ /simple_expr: name_tag . /expr: name_tag . simple_expr ]
implementation CHAR @ WHEN UNDERSCORE DOTDOT [ /constant: CHAR . ] [ /simple_expr: constant . ]
...
```

A line is composed as follow:
1) The first symbol `implementation` is the entrypoint (we are parsing an `implementation`)
2) It is followed by `BACKQUOTE UIDENT`, the terminals making up the valid prefix
3) separated by `@` is the list of lookaheads that cause the parse to fail: `error WHILE WHEN VIRTUAL UNDERSCORE TRY STRUCT SIG REC QUOTE PRIVATE OF OBJECT NONREC MUTABLE MATCH LETOP LESSMINUS LBRACKETLESS LBRACKETGREATER LAZY IF FUNCTOR FUNCTION FUN FOR DOTDOT DOCSTRING COMMENT ASSERT AS`
4) Separated by `#` is the list of states reached by reducing the input failing: `[ /ident: UIDENT . ]`, `[ /name_tag: BACKQUOTE ident . ]`, `[ /simple_expr: name_tag . /expr: name_tag . simple_expr ]`. Each state is represented as a list of items. It means that the `UIDENT` is first reduced to an `ident`, this `ident` and the preceding `BACKQUOTE` are reduced to a `name_tag`, which is itself part of a `simple_expr`.

The first three components mean that a file `foo.ml` beginning with `` `FOO `` will fail to parse if it is followed by `while`, `when`, `virtual`, `_`, etc. (`error` is a special token that can be ignored).

The pattern `BACKQUOTE; UIDENT` will match this case, but it is too vague: it says nothing about the context in which this prefix failed. To make an error rule from that, we can look at the fourth component. The patterns:

```
| [ _* /ident: UIDENT . ]
| [ _* /name_tag: BACKQUOTE ident . ]
| [ _* /simple_expr: name_tag . /expr: name_tag . simple_expr ]
```

will all match this situation. The third one is arguably the best: it tells us that we already identified an expression. An error clause for this case can be:

```
| [_* /expr: name_tag . simple_expr] 
  { "Expecting an argument after the tag (e.g `A 42), or the continuation of the outer expression" }
```

Since this doesn't tell us much about what can come next, this clause should have a low priority.

# Precision of the enumeration

The enumeration produce enough sentences to go through all reductions for all lookaheads that can make them fail.

For instance, grepping for `[ /simple_expr: name_tag . /expr: name_tag . simple_expr ]` in the enumeration gives us three other sentences that go through the same reduction, but that will fail for different lookaheads.

This is useful to get a better idea of the different situations in which this specific error can happen.

The argument `lr0`, `lr1`, and `goto` make the enumeration more or less verbose:
- `lr0` identify a reduction as the target state that is reached after reducing it
- `lr1` does almost the same, but can distinguish slightly more states based on the lookahead token used to reach same
- `goto` is the most precise and cover the goto transitions (the source and the target of the reduction are considered, for instance reducing an expression after `+` and after `-` will be treated as different situations).

In practice, `lr0` is sufficient to study the grammar as a "human being". `goto` can be useful for automatic fuzzing, for instance for checking parser conformance and comparing error messages. For the OCaml grammar:
- `lr0` produces 3.6k sentences and 600k lookaheads
- `goto` produces 33k sentences and millions of lookaheads

# Output format

The default output format is dense but convenient for processing the output with shell tools and in simple scripts.
The JSON format outputs a sequence of line delimited JSON objects is convenient for post-processing the output, for instance to provide input to a fuzzer and check error message coverage for a grammar. Objects have the following form:
```json
{
  "entrypoint":"start_symbol",
  "sentence":["TERM1", "TERM2", ...],
  "lookaheads":["TERM3", "TERM4", ...],
  "states":[[{"lhs":"nonterminal","rhs":["sym1","sym2",...],"dot": n}, ...], ...]
}
```

Symbols are represented as strings. The entrypoint is a single non-terminal symbol.
Sentence and lookaheads are a list of terminal symbols.
States is an ordered list of states (reach by following reductions). A state is a list of items, and an item is an object `{"lhs":"nonterminal", "rhs":["symbol";"list"], "dot": n}`.
`n` is the position of the dot in the item, starting from 0.
For instance: `x: A . B` is represented as `{"lhs":"x", "rhs": ["A", "B"], "dot": 1}`.

The example output of OCaml grammar above is represented as:
```json
{
  "entrypoint":"implementation",
  "sentence": ["BACKQUOTE", "UIDENT"],
  "lookaheads": ["error", "WHILE", "WHEN", "VIRTUAL", ...],
  "states": [
    [ {"lhs": "ident", "rhs":["UIDENT"], "dot":1} ],
    [ {"lhs": "name_tag", "rhs":["BACKQUOTE", "ident"], "dot":2} ],
    [ {"lhs": "simple_expr", "rhs":["name_tag"], "dot":1},
      {"lhs":"expr","rhs":["name_tag", "simple_expr"], "dot":1} ] ]
}
```